### PR TITLE
Add !spells command for magic book display

### DIFF
--- a/data/talkactions/scripts/spells.lua
+++ b/data/talkactions/scripts/spells.lua
@@ -1,0 +1,41 @@
+function onSay(cid, words, param)
+	local count = getPlayerInstantSpellCount(cid)
+	local spellsText = ""
+	local collected = {}
+
+	for i = 0, count - 1 do
+		local spell = getPlayerInstantSpellInfo(cid, i)
+		if spell.level ~= 0 then
+			if spell.manapercent and spell.manapercent > 0 then
+				spell.mana = spell.manapercent .. "%"
+			end
+			collected[#collected + 1] = spell
+		end
+	end
+
+	table.sort(collected, function(a, b)
+		return a.level < b.level
+	end)
+
+	if #collected == 0 then
+		Player(cid):sendTextMessage(MESSAGE_STATUS_CONSOLE_BLUE, "Nie znasz żadnych czarów.")
+		return false
+	end
+
+	local previousLevel = -1
+	for i, spell in ipairs(collected) do
+		local line = ""
+		if previousLevel ~= spell.level then
+			if i ~= 1 then
+				line = "\n"
+			end
+			line = line .. "Spells for Level " .. spell.level .. "\n"
+			previousLevel = spell.level
+		end
+		spellsText = spellsText .. line .. "  " .. spell.words .. " - " .. spell.name .. " : " .. spell.mana .. "\n"
+	end
+
+	-- 2175 is the classic spellbook item id; used only as a dialog skin here
+	Player(cid):showTextDialog(2175, spellsText)
+	return false
+end

--- a/data/talkactions/talkactions.xml
+++ b/data/talkactions/talkactions.xml
@@ -43,6 +43,7 @@
 	<talkaction words="!kills" script="kills.lua"/>
 	<talkaction words="!online" script="online.lua"/>
 	<talkaction words="!serverinfo" script="serverinfo.lua"/>
+	<talkaction words="!spells" script="spells.lua"/>
 
 	<!-- test talkactions -->
 	<talkaction words="!z" separator=" " script="magiceffect.lua"/>


### PR DESCRIPTION
Adds a `!spells` talkaction command to display a player's learned spells in an in-game dialog.

---
<a href="https://cursor.com/background-agent?bcId=bc-a47c3cd5-ccde-44d8-8d86-5239d4dac97b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a47c3cd5-ccde-44d8-8d86-5239d4dac97b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

